### PR TITLE
fix: Bump cmake_minimum_required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(termistor)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)


### PR DESCRIPTION
Last week CMake 4.0 released and it is in available in some bleeding edge distros like Arch Linux and it will be available in other distros soon.

Compatibility with CMake < 3.5 has been removed from CMake 4.0.

So we need to update the `VERSION` argument `<min>` value. Or, use the `<min>...<max>` syntax to tell CMake that the project requires at least `<min>` but has been updated to work with policies introduced by `<max>` or earlier.

Or, we need add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to cmake arguments to try configuring anyway.

I changed `<min>` to `3.5`, so we can build with cmake >= 4.0.