### PR TITLE
fix: Replace SIGUNUSED with SIGSYS and use _GNU_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(termistor)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/libtsm/src/shared/shl-pty.c
+++ b/libtsm/src/shared/shl-pty.c
@@ -9,6 +9,8 @@
  * PTY Helpers
  */
 
+#define _GNU_SOURCE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -146,7 +148,7 @@ static int pty_init_child(int fd)
 	if (r < 0)
 		return -errno;
 
-	for (i = 1; i < SIGUNUSED; ++i)
+	for (i = 1; i < SIGSYS; ++i)
 		signal(i, SIG_DFL);
 
 	r = grantpt(fd);


### PR DESCRIPTION
The `SIGUNUSED` define was removed from glibc version 2.26 in August 2017. So Termistor cannot be built on GNU/Linux distributions that use glibc>=2.26, such as Fedora>=27 and Ubuntu>=17.10.

From the [signal(7) man page](https://man7.org/linux/man-pages/man7/signal.7.html):

```
       SIGUNUSED      -        Core    Synonymous with SIGSYS
```

After changing `SIGUNSED` to `SIGSYS`, there are other problems raise while building the code:

* `grantpt`, `unlockpt` and `ptsname` functions, need `_XOPEN_SOURCE >= 500` feature test macro.
* `posix_openpt` function needs `_XOPEN_SOURCE >= 600` feature test macro.
* `pipe2` function needs `_GNU_SOURCE` feature test macro.

Since `_GNU_SOURCE` implies nearly all feature test macros, adding `_GNU_SOURCE` is sufficient.